### PR TITLE
chore: fix release order in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-## 0.0.1
-
-* Initial release
-## 0.0.2
-
-* Small fixes
 ## 0.0.3
 
-* Migrated the input text removing toolbarOptions field
+- Migrated the input text removing toolbarOptions field
+
+## 0.0.2
+
+- Small fixes
+
+## 0.0.1
+
+- Initial release


### PR DESCRIPTION
Changes the order of release entries in the CHANGELOG.md file.

On pub.dev, the newest release of the package should be at the top. Imagine, if you have a long list of updates, it would be tedious to scroll to the bottom of the changelog to see what new was added since the last update. For more information, check [the official Dart documentation](https://dart.dev/tools/pub/package-layout#changelog).