### PR TITLE
Bring flutter_virtual_keyboard to pub.dev 160/160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.1.0
+
+- Replaced the deprecated `ThemeData.dialogBackgroundColor` with
+  `DialogThemeData.backgroundColor` (falls back to `colorScheme.surface`),
+  fixing compatibility with Flutter 3.27+ and earning pub.dev static-analysis
+  50/50.
+- Resolved all remaining analyzer issues (`use_super_parameters`,
+  `library_private_types_in_public_api`, `prefer_const_constructors`,
+  `sized_box_for_whitespace`) and removed unused fields from the example.
+- Added a real test suite (key model + style background-color resolution);
+  the previous test file was empty.
+
 ## 0.0.3
 
 - Migrated the input text removing toolbarOptions field

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,9 +33,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   final TextEditingController _textEditingController = TextEditingController();
-  final TextEditingController _textEditingController2 = TextEditingController();
   final ScrollController _scrollController = ScrollController();
-  final ScrollController _scrollController2 = ScrollController();
 
   @override
   Widget build(BuildContext context) {
@@ -64,7 +62,7 @@ class _MyHomePageState extends State<MyHomePage> {
             // ),
             InkWell(
               onTap: () {},
-              child: Container(
+              child: const SizedBox(
                 height: 50,
                 width: 50,
               ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,26 +21,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -81,31 +81,31 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.3"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -118,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -134,23 +134,23 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -163,18 +163,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -195,18 +195,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "14.2.5"
 sdks:
-  dart: ">=3.5.4 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/flutter_virtual_keyboard/style/virtual_keyboard_style.dart
+++ b/lib/flutter_virtual_keyboard/style/virtual_keyboard_style.dart
@@ -32,7 +32,10 @@ class VirtualKeyboardStyle {
 
   ThemeData get _theme => Theme.of(_context);
 
-  Color get backgroundColor => _backgroundColor ?? _theme.dialogBackgroundColor;
+  Color get backgroundColor =>
+      _backgroundColor ??
+      _theme.dialogTheme.backgroundColor ??
+      _theme.colorScheme.surface;
 
   TextStyle get keysTextStyle =>
       _keysTextStyle ?? _theme.textTheme.bodyMedium ?? const TextStyle();

--- a/lib/flutter_virtual_keyboard/widgets/keyboard_body.dart
+++ b/lib/flutter_virtual_keyboard/widgets/keyboard_body.dart
@@ -4,11 +4,11 @@ import 'package:flutter_virtual_keyboard/virtual_keyboard.dart';
 
 class KeyboardBody extends StatefulWidget {
   const KeyboardBody({
-    Key? key,
+    super.key,
     this.insetsState,
     this.slideAnimation,
     required this.child,
-  }) : super(key: key);
+  });
 
   final KeyboardViewInsetsState? insetsState;
 
@@ -21,7 +21,7 @@ class KeyboardBody extends StatefulWidget {
   final Widget child;
 
   @override
-  _KeyboardBodyState createState() => _KeyboardBodyState();
+  State<KeyboardBody> createState() => _KeyboardBodyState();
 }
 
 class _KeyboardBodyState extends State<KeyboardBody> {

--- a/lib/flutter_virtual_keyboard/widgets/virtual_keyboard.dart
+++ b/lib/flutter_virtual_keyboard/widgets/virtual_keyboard.dart
@@ -93,7 +93,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
   @override
   Widget build(BuildContext context) {
     final curvedSlideAnimation = CurvedAnimation(
-      parent: AlwaysStoppedAnimation(1),
+      parent: const AlwaysStoppedAnimation(1),
       curve: Curves.ease,
     );
     return SlideTransition(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_virtual_keyboard
 description: "This package offers a customizable virtual keyboard, enabling easy integration for typing functionality in apps."
-version: 0.0.3
+version: 0.1.0
 repository: "https://github.com/ICE-Felix/virtual_keyboard.git"
 
 environment:

--- a/test/virtual_keyboard_test.dart
+++ b/test/virtual_keyboard_test.dart
@@ -1,1 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_virtual_keyboard/virtual_keyboard.dart';
 
+void main() {
+  group('VirtualKeyboardKey', () {
+    test('letter keys use their enum name as value', () {
+      expect(VirtualKeyboardKey.q.value, 'q');
+      expect(VirtualKeyboardKey.m.value, 'm');
+    });
+
+    test('digit keys expose their numeric value', () {
+      expect(VirtualKeyboardKey.zero.value, '0');
+      expect(VirtualKeyboardKey.nine.value, '9');
+    });
+
+    test('punctuation and spacebar expose their literal value', () {
+      expect(VirtualKeyboardKey.comma.value, ',');
+      expect(VirtualKeyboardKey.period.value, '.');
+      expect(VirtualKeyboardKey.spacebar.value, ' ');
+    });
+
+    test('displayValue prefers an explicit display label', () {
+      expect(VirtualKeyboardKey.caps.displayValue, 'CAPS');
+      expect(VirtualKeyboardKey.spacebar.displayValue, '␣');
+      expect(VirtualKeyboardKey.backspace.displayValue, '⌫');
+      expect(VirtualKeyboardKey.enter.displayValue, '⏎');
+    });
+
+    test('displayValue falls back to value/name when no label is set', () {
+      expect(VirtualKeyboardKey.q.displayValue, 'q');
+      expect(VirtualKeyboardKey.zero.displayValue, '0');
+    });
+
+    test('text layout has 4 rows and starts with the q..p row', () {
+      final rows = VirtualKeyboardKey.textKeyboardKeys;
+      expect(rows.length, 4);
+      expect(rows.first.length, 10);
+      expect(rows.first.first, VirtualKeyboardKey.q);
+      expect(rows.first.last, VirtualKeyboardKey.p);
+    });
+
+    test('numeric layout has 4 rows', () {
+      expect(VirtualKeyboardKey.numericKeyboardKeys.length, 4);
+      expect(VirtualKeyboardKey.numericKeyboardKeys.first.first,
+          VirtualKeyboardKey.seven);
+    });
+  });
+
+  group('VirtualKeyboardStyle.backgroundColor', () {
+    test('an explicit background color takes precedence over the theme', () {
+      final style =
+          VirtualKeyboardStyle(backgroundColor: const Color(0xFFABCDEF));
+      // No BuildContext needed: the explicit value short-circuits the theme.
+      expect(style.backgroundColor, const Color(0xFFABCDEF));
+    });
+
+    testWidgets('falls back to the dialog theme background color',
+        (tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            dialogTheme:
+                const DialogThemeData(backgroundColor: Color(0xFF123456)),
+          ),
+          home: Builder(
+            builder: (context) {
+              ctx = context;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      final style = VirtualKeyboardStyle()..setBuildContext(ctx);
+      expect(style.backgroundColor, const Color(0xFF123456));
+    });
+
+    testWidgets('falls back to colorScheme.surface when no dialog color is set',
+        (tester) async {
+      late BuildContext ctx;
+      late ThemeData theme;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              ctx = context;
+              theme = Theme.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      final style = VirtualKeyboardStyle()..setBuildContext(ctx);
+      expect(style.backgroundColor, theme.colorScheme.surface);
+    });
+  });
+}


### PR DESCRIPTION
Brings `flutter_virtual_keyboard` from 150 → **160/160 pub points** (verified with `pana`).

## Changes
- **Deprecation fix**: `ThemeData.dialogBackgroundColor` → `DialogThemeData.backgroundColor` (falls back to `colorScheme.surface`). This was the sole cause of the static-analysis deduction.
- **Other analyzer issues** resolved: `use_super_parameters`, `library_private_types_in_public_api`, `prefer_const_constructors`, `sized_box_for_whitespace`; removed unused fields from the example.
- **Tests**: the test file was empty (test run failed to compile). Added a real suite covering the `VirtualKeyboardKey` model and `VirtualKeyboardStyle.backgroundColor` resolution (incl. the deprecation fix).
- **Version**: 0.1.0; CHANGELOG updated.

## Verification
- `flutter analyze` → No issues found!
- `flutter test` → 10/10 passing
- `pana` → **160/160** (static analysis 50/50, 6/6 platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)